### PR TITLE
イベントポスト画面に戻るを実装

### DIFF
--- a/OkaEvent_iOS/Post.storyboard
+++ b/OkaEvent_iOS/Post.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -178,6 +178,11 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" title="投稿" id="43F-dc-4df">
+                        <barButtonItem key="leftBarButtonItem" title="Cancel" id="hfZ-fW-l2b">
+                            <connections>
+                                <action selector="cancelTapped:" destination="NA3-BZ-knb" id="ci5-yK-G6d"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" title="投稿" id="3vA-0v-eCT">
                             <connections>
                                 <action selector="postTapped:" destination="NA3-BZ-knb" id="UfK-zk-0jj"/>

--- a/OkaEvent_iOS/PostEventTableViewController.swift
+++ b/OkaEvent_iOS/PostEventTableViewController.swift
@@ -44,6 +44,10 @@ class PostEventTableViewController: UITableViewController, UITextFieldDelegate, 
             endDateTimeTextField.text != ""
     }
     
+    @IBAction func cancelTapped(_ sender: Any) {
+        dismiss(animated: true, completion: nil)
+    }
+
     //textFieldのフォーカスが移動したら呼ばれる
     func textFieldDidEndEditing(_ textField: UITextField) {
         //前後の余計な余白を削除


### PR DESCRIPTION
## やったこと
* イベント投稿画面に、戻るボタンがなかったので実装しました。

---
![simulator screen shot - iphone 8 plus - 2018-09-16 at 14 03 50](https://user-images.githubusercontent.com/12871716/45593148-042e5100-b9ba-11e8-9241-b0e05b0dae74.png)
